### PR TITLE
Fix issues from template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ requirements.txt
 # virtual environment
 venv/
 
+# Python cache
+__pycache__/
+
 # Ruff cache
 .ruff_cache/

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ PYTHON_VERSION = 3.12.1
 # Python version without release number
 PYTHON_SHORT_VERSION = $(shell echo $(PYTHON_VERSION) | sed -r "s/^([[:digit:]]+\.[[:digit:]]+)\..*$$/\1/g")
 
+# Python version for Ruff
+PYTHON_RUFF_VERSION = $(shell echo $(PYTHON_VERSION) | sed -r "s/^([[:digit:]]+)\.([[:digit:]]+)\..*$$/py\1\2/g")
+
 # Python version file
 PYTHON_VERSION_FILE = .python-version
 
@@ -68,7 +71,7 @@ format : | $(VENV_ACTIVATE)
 # set Ruff `target-version`
 .PHONY : set-ruff-target-version
 set-ruff-target-version : $(PYTHON_VERSION_FILE)
-	sed -r -i "" "s/^(target-version = ).*$$/\1\"$(RUFF_TARGET_VERSION)\"/g" "pyproject.toml"
+	sed -r -i "" "s/^(target-version = ).*$$/\1\"$(PYTHON_RUFF_VERSION)\"/g" "pyproject.toml"
 
 
 # ==========


### PR DESCRIPTION
There were 2 issues in [Python Project Template](https://github.com/victordumetz/python-project-template) from which the repository was created:

- the Ruff `target-version` was always set to an empty string
- the Python cache folders were not ignored

This fixes the issues by adding `__pycache__/` to `.gitignore` and setting the `RUFF_TARGET_VERSION` variable in the `Makefile`. `RUFF_TARGET_VERSION` has been renamed to `PYTHON_RUFF_VERSION` for consistency.