### PR TITLE
Fix testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,4 +23,4 @@ jobs:
       - uses: victordumetz/python-project-template/.github/actions/setup-venv@v1
 
       - name: Run tests
-        run: pytest
+        run: python -m pytest

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,14 @@ format : | $(VENV_ACTIVATE)
 set-ruff-target-version : $(PYTHON_VERSION_FILE)
 	sed -r -i "" "s/^(target-version = ).*$$/\1\"$(PYTHON_RUFF_VERSION)\"/g" "pyproject.toml"
 
+# ==========
+# PYTEST TESTING
+# ==========
+
+# run pytest
+.PHONY : test
+test : | $(VENV_ACTIVATE)
+	$(PYTHON) -m pytest
 
 # ==========
 # PYTHON


### PR DESCRIPTION
Testing could not resolve some paths due to running `pytest` only.

Tests are now run through the `python -m pytest` command.

Add a `test` Make rule that runs pytest.